### PR TITLE
fix: Correct LICENSE format - remove misplaced SAGE text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -171,10 +171,7 @@ Library.
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+                            Preamble
 
   The GNU General Public License is a free, copyleft license for
 software and other kinds of works.
@@ -234,7 +231,8 @@ to avoid the special danger that patents applied to a free program could
 make it effectively proprietary.  To prevent this, the GPL assures that
 patents cannot be used to render the program non-free.
 
-SAGE - Secure Agent Guarantee Engine
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
                        TERMS AND CONDITIONS
 


### PR DESCRIPTION
## Problem

During the merge of PR #33 (dev → main), the LICENSE file was incorrectly merged, resulting in "SAGE - Secure Agent Guarantee Engine" text being inserted in the middle of the GNU GPL section at line 237.

**Incorrect LICENSE** (current main):
- 842 lines
- Line 237: "SAGE - Secure Agent Guarantee Engine" (misplaced)
- Breaks standard LGPL-3.0 format

## Solution

This hotfix restores the correct LGPL-3.0 license text:

**Correct LICENSE** (this PR):
- 840 lines (standard format)
- No misplaced project name
- Pure LGPL-3.0 + GPL-3.0 text

## Changes

- Remove "SAGE - Secure Agent Guarantee Engine" from line 237
- Restore standard GNU LGPL v3.0 + GPL v3.0 structure
- Total change: -2 lines (842 → 840)

## Verification

\`\`\`bash
# Check line count
wc -l LICENSE
# 840 LICENSE ✓

# Verify no misplaced SAGE text
grep -n "SAGE - Secure Agent" LICENSE
# (no output) ✓
\`\`\`

## Impact

- **License validity**: ✓ Restored to valid LGPL-3.0 format
- **Compliance**: ✓ No functional changes, formatting only
- **Breaking changes**: None