### PR TITLE
fix(ci): Convert Docker image name to lowercase in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Convert repository name to lowercase
+        run: |
+          echo "IMAGE_NAME_LOWER=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -173,7 +177,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ env.IMAGE_NAME_LOWER }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
## Description

This hotfix addresses an inconsistency in the release workflow where the Docker image name uses uppercase characters, which is not compatible with GitHub Container Registry (ghcr.io).

## Problem

The `docker-release` job in `release.yml` uses:
```yaml
images: ghcr.io/${{ github.repository }}
```

This results in `ghcr.io/SAGE-X-project/sage` which contains uppercase characters. However, **ghcr.io only accepts lowercase image names**, which will cause the Docker build to fail during release.

## Solution

Added lowercase conversion step to the `docker-release` job, consistent with the fix already applied in `docker.yml` (PR #71):

1. Convert repository name to lowercase before use
2. Update metadata action to use the lowercase image name

## Changes Made

- Added `Convert repository name to lowercase` step in docker-release job
- Updated `images` parameter to use `${{ env.IMAGE_NAME_LOWER }}`

## Testing

This change ensures consistency with `docker.yml` which already has this fix and is working correctly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD improvement

## Related Issues

Follow-up to PR #71 which fixed the same issue in docker.yml but missed release.yml

---

**Priority:** High - This will cause release workflow failures when v* tags are pushed